### PR TITLE
feat: add clipboard image support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Upload food images and get AI-powered predictions for 101 different food categor
 
 ## 📱 Features
 - 📸 Upload any food image
-- 📋 Paste image from clipboard
+- 📋 Paste image from clipboard (click the dashed area then press Ctrl+V)
 - 🤖 AI classification with confidence scores
 - 📊 Top predictions visualization
 - 🎨 Beautiful, responsive interface

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Upload food images and get AI-powered predictions for 101 different food categor
 
 ## 📱 Features
 - 📸 Upload any food image
+- 📋 Paste image from clipboard
 - 🤖 AI classification with confidence scores
 - 📊 Top predictions visualization
 - 🎨 Beautiful, responsive interface

--- a/USAGE_GUIDE.md
+++ b/USAGE_GUIDE.md
@@ -35,6 +35,7 @@ The original model compatibility issue has been resolved by converting the model
 
 ### Web Interface
 - **Drag & drop image upload** (JPG, JPEG, PNG)
+- **Paste image from clipboard**
 - **Real-time predictions** with confidence scores
 - **Top-K predictions** (adjustable 1-10)
 - **Visual confidence bars** for top 3 predictions

--- a/USAGE_GUIDE.md
+++ b/USAGE_GUIDE.md
@@ -35,7 +35,7 @@ The original model compatibility issue has been resolved by converting the model
 
 ### Web Interface
 - **Drag & drop image upload** (JPG, JPEG, PNG)
-- **Paste image from clipboard**
+- **Paste image from clipboard** (click the dashed area then press Ctrl+V)
 - **Real-time predictions** with confidence scores
 - **Top-K predictions** (adjustable 1-10)
 - **Visual confidence bars** for top 3 predictions

--- a/src/app.py
+++ b/src/app.py
@@ -210,7 +210,6 @@ def main() -> None:
             </script>
             """,
             height=150,
-            key="paste_component",
         )
         top_k = st.slider(
             "Number of predictions to show:",

--- a/src/app.py
+++ b/src/app.py
@@ -26,6 +26,15 @@ sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 from util import get_data_list  # noqa: E402
 
 
+def image_from_data_url(data_url: str) -> Optional[Image.Image]:
+    """Decode a base64 data URL into a PIL Image."""
+    try:
+        header, encoded = data_url.split(",", 1)
+        return Image.open(BytesIO(base64.b64decode(encoded)))
+    except Exception:  # noqa: BLE001 - invalid data URL
+        return None
+
+
 def load_model_robust(model_path: str) -> Optional[tf.keras.Model]:
     """Attempt to load a model using multiple fallback strategies.
 
@@ -187,11 +196,12 @@ def main() -> None:
         st.markdown("**Or paste from clipboard**")
         pasted_image_data = components.html(
             """
-            <div id='paste-area' style='border:2px dashed #ccc; border-radius:8px; padding:20px; text-align:center;'>
+            <div id='paste-area' contenteditable='true' style='border:2px dashed #ccc; border-radius:8px; padding:20px; text-align:center;'>
                 Click here and press Ctrl+V to paste an image
             </div>
             <script>
             const pasteArea = document.getElementById('paste-area');
+            pasteArea.addEventListener('click', () => pasteArea.focus());
             pasteArea.addEventListener('paste', function(event) {
                 const items = (event.clipboardData || event.originalEvent.clipboardData).items;
                 for (const item of items) {
@@ -211,6 +221,10 @@ def main() -> None:
             """,
             height=150,
         )
+        if pasted_image_data is not None:
+            st.session_state["pasted_image_data"] = pasted_image_data
+        elif "pasted_image_data" in st.session_state:
+            pasted_image_data = st.session_state["pasted_image_data"]
         top_k = st.slider(
             "Number of predictions to show:",
             min_value=1,
@@ -225,11 +239,7 @@ def main() -> None:
         if uploaded_file is not None:
             image = Image.open(uploaded_file)
         elif pasted_image_data:
-            try:
-                header, encoded = pasted_image_data.split(",", 1)
-                image = Image.open(BytesIO(base64.b64decode(encoded)))
-            except Exception:
-                image = None
+            image = image_from_data_url(pasted_image_data)
 
         if image is not None:
             try:

--- a/src/app.py
+++ b/src/app.py
@@ -194,7 +194,7 @@ def main() -> None:
             help="Upload a clear image of food for best results",
         )
         st.markdown("**Or paste from clipboard**")
-        pasted_image_data = components.html(
+        raw_pasted_data = components.html(
             """
             <div id='paste-area' contenteditable='true' style='border:2px dashed #ccc; border-radius:8px; padding:20px; text-align:center;'>
                 Click here and press Ctrl+V to paste an image
@@ -221,10 +221,9 @@ def main() -> None:
             """,
             height=150,
         )
-        if pasted_image_data is not None:
-            st.session_state["pasted_image_data"] = pasted_image_data
-        elif "pasted_image_data" in st.session_state:
-            pasted_image_data = st.session_state["pasted_image_data"]
+        if isinstance(raw_pasted_data, str) and raw_pasted_data:
+            st.session_state["pasted_image_data"] = raw_pasted_data
+        pasted_image_data = st.session_state.get("pasted_image_data")
         top_k = st.slider(
             "Number of predictions to show:",
             min_value=1,
@@ -238,7 +237,7 @@ def main() -> None:
         image = None
         if uploaded_file is not None:
             image = Image.open(uploaded_file)
-        elif pasted_image_data:
+        elif isinstance(pasted_image_data, str):
             image = image_from_data_url(pasted_image_data)
 
         if image is not None:

--- a/src/app.py
+++ b/src/app.py
@@ -16,6 +16,9 @@ import pandas as pd
 import streamlit as st
 import tensorflow as tf
 from PIL import Image
+import base64
+from io import BytesIO
+import streamlit.components.v1 as components
 
 # Add the src directory to Python path to import custom modules
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
@@ -152,7 +155,7 @@ def main() -> None:
     st.sidebar.title("📋 Instructions")
     st.sidebar.markdown(
         """
-        1. Upload a food image using the file uploader
+        1. Upload or paste a food image
         2. The app will automatically predict the food type
         3. View the top predictions with confidence scores
         4. Try different food images to test the model!
@@ -173,12 +176,41 @@ def main() -> None:
 
     col1, col2 = st.columns([1, 1])
 
+    pasted_image_data = None
     with col1:
         st.subheader("📤 Upload Food Image")
         uploaded_file = st.file_uploader(
             "Choose a food image...",
             type=["jpg", "jpeg", "png"],
             help="Upload a clear image of food for best results",
+        )
+        st.markdown("**Or paste from clipboard**")
+        pasted_image_data = components.html(
+            """
+            <div id='paste-area' style='border:2px dashed #ccc; border-radius:8px; padding:20px; text-align:center;'>
+                Click here and press Ctrl+V to paste an image
+            </div>
+            <script>
+            const pasteArea = document.getElementById('paste-area');
+            pasteArea.addEventListener('paste', function(event) {
+                const items = (event.clipboardData || event.originalEvent.clipboardData).items;
+                for (const item of items) {
+                    if (item.type.indexOf('image') !== -1) {
+                        const file = item.getAsFile();
+                        const reader = new FileReader();
+                        reader.onload = function(e) {
+                            const dataUrl = e.target.result;
+                            window.parent.postMessage({isStreamlitMessage: true, type: 'streamlit:setComponentValue', value: dataUrl}, '*');
+                        };
+                        reader.readAsDataURL(file);
+                    }
+                }
+                event.preventDefault();
+            });
+            </script>
+            """,
+            height=150,
+            key="paste_component",
         )
         top_k = st.slider(
             "Number of predictions to show:",
@@ -190,9 +222,18 @@ def main() -> None:
 
     with col2:
         st.subheader("🔍 Predictions")
+        image = None
         if uploaded_file is not None:
+            image = Image.open(uploaded_file)
+        elif pasted_image_data:
             try:
-                image = Image.open(uploaded_file)
+                header, encoded = pasted_image_data.split(",", 1)
+                image = Image.open(BytesIO(base64.b64decode(encoded)))
+            except Exception:
+                image = None
+
+        if image is not None:
+            try:
                 # Center and scale the uploaded image preview so it appears smaller
                 img_left, img_center, img_right = st.columns([1, 2, 1])
                 with img_center:

--- a/test_clipboard.py
+++ b/test_clipboard.py
@@ -14,3 +14,8 @@ def test_image_from_data_url():
     decoded = image_from_data_url(data_url)
     assert decoded is not None
     assert decoded.size == (5, 5)
+
+
+def test_image_from_data_url_invalid_returns_none():
+    assert image_from_data_url("invalid") is None
+    assert image_from_data_url(None) is None  # type: ignore[arg-type]

--- a/test_clipboard.py
+++ b/test_clipboard.py
@@ -1,0 +1,16 @@
+from io import BytesIO
+import base64
+from PIL import Image
+
+from src.app import image_from_data_url
+
+def test_image_from_data_url():
+    # create a simple red image and encode it as data URL
+    img = Image.new('RGB', (5, 5), color='red')
+    buf = BytesIO()
+    img.save(buf, format='PNG')
+    data_url = 'data:image/png;base64,' + base64.b64encode(buf.getvalue()).decode('utf-8')
+
+    decoded = image_from_data_url(data_url)
+    assert decoded is not None
+    assert decoded.size == (5, 5)


### PR DESCRIPTION
## Summary
- allow users to paste images from clipboard for classification
- document clipboard pasting in readme and usage guide

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1e3fcc838832883ed4ffece8f87ef